### PR TITLE
Fix validator compile

### DIFF
--- a/config/src/validator.rs
+++ b/config/src/validator.rs
@@ -107,15 +107,6 @@ impl ConfigValidator {
         
         Ok(())
     }
-            if endpoint.circuit_breaker_threshold < 0.0 || endpoint.circuit_breaker_threshold > 1.0 {
-                return Err(ConfigError::Validation(
-                    format!("{} circuit breaker threshold must be between 0.0 and 1.0", name)
-                ));
-            }
-        }
-        
-        Ok(())
-    }
     
     fn validate_ai(ai: &crate::config::AIConfig) -> Result<()> {
         // Validate LLM config
@@ -311,7 +302,7 @@ mod tests {
     #[test]
     fn test_validate_invalid_port() {
         let mut config = FinalverseConfig::default();
-        config.network.port = 0;
+        config.network.api_port = 0;
         assert!(ConfigValidator::validate(&config).is_err());
     }
     

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -15,3 +15,4 @@ ratatui = "0.29.0"
 serde.workspace = true
 tokio.workspace = true
 tokio-tungstenite = "0.26.2"
+reqwest.workspace = true

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -30,7 +30,7 @@ use std::{
 };
 use tokio::{
     net::{TcpListener, TcpStream},
-    sync::{broadcast, mpsc, RwLock},
+    sync::{broadcast, mpsc, RwLock, Mutex as TokioMutex},
     time::interval,
 };
 use tokio_tungstenite::{accept_async, tungstenite::Message};
@@ -116,7 +116,7 @@ pub struct ServerManager {
     processes: Arc<Mutex<HashMap<String, Child>>>,
     log_buffer: Arc<RwLock<VecDeque<LogEntry>>>,
     command_tx: mpsc::UnboundedSender<ServerCommand>,
-    command_rx: Arc<Mutex<mpsc::UnboundedReceiver<ServerCommand>>>,
+    command_rx: Arc<TokioMutex<mpsc::UnboundedReceiver<ServerCommand>>>,
     broadcast_tx: broadcast::Sender<ServerResponse>,
 }
 
@@ -130,7 +130,7 @@ impl ServerManager {
             processes: Arc::new(Mutex::new(HashMap::new())),
             log_buffer: Arc::new(RwLock::new(VecDeque::with_capacity(10000))),
             command_tx,
-            command_rx: Arc::new(Mutex::new(command_rx)),
+            command_rx: Arc::new(TokioMutex::new(command_rx)),
             broadcast_tx,
         }
     }
@@ -316,7 +316,7 @@ impl ServerManager {
         let broadcast_tx = self.broadcast_tx.clone();
 
         tokio::spawn(async move {
-            let mut rx = command_rx.lock().unwrap();
+            let mut rx = command_rx.lock().await;
             while let Some(command) = rx.recv().await {
                 match command {
                     ServerCommand::StartService(name) => {


### PR DESCRIPTION
## Summary
- fix cut off validator
- update validator test
- fix command receiver spawn with Tokio mutex
- add reqwest to server

## Testing
- `cargo check -p finalverse-config` *(fails: Failure when receiving data)*
- `cargo check -p finalverse-server` *(fails: Failure when receiving data)*
- `cargo check -p finalverse-cli` *(fails: Failure when receiving data)*


------
https://chatgpt.com/codex/tasks/task_e_6848f8b2a7548332816179cd2fd4a18a