### PR TITLE
Add gRPC registry and realtime gateway

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "services/community",
     "services/asset-service",
     "services/websocket-gateway",
+    "services/realtime-gateway",
     "services/service-registry",
     "services/plugin",
     "plugins/greeter-plugin",
@@ -103,3 +104,4 @@ toml = "0.8"
 num_cpus = "1.16"
 clap = { version = "4.4", features = ["derive"] }
 rustyline = "13.0"
+once_cell = "1.19"

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -11,6 +11,18 @@ serde = { workspace = true, features = ["derive"] }
 toml.workspace = true
 thiserror.workspace = true
 num_cpus.workspace = true
+axum.workspace = true
+tokio.workspace = true
+tracing-subscriber.workspace = true
+anyhow.workspace = true
+
+[lib]
+name = "finalverse_config"
+path = "src/lib.rs"
+
+[[bin]]
+name = "finalverse-config"
+path = "src/main.rs"
 
 [dev-dependencies]
 tempfile = "3.8"

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -2,6 +2,7 @@
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::net::SocketAddr;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FinalverseConfig {
@@ -15,6 +16,7 @@ pub struct FinalverseConfig {
     pub performance: PerformanceConfig,
     pub monitoring: MonitoringConfig,
     pub game: GameConfig,
+    pub grpc_services: GrpcServiceRegistry,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -91,6 +93,26 @@ pub struct ServiceEndpoint {
     pub timeout_ms: u64,
     pub max_retries: u32,
     pub circuit_breaker_threshold: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GrpcServiceRegistry {
+    pub services: HashMap<String, SocketAddr>,
+}
+
+impl GrpcServiceRegistry {
+    pub fn new(map: HashMap<String, SocketAddr>) -> Self {
+        Self { services: map }
+    }
+}
+
+impl Default for GrpcServiceRegistry {
+    fn default() -> Self {
+        let mut map = HashMap::new();
+        map.insert("song-engine".to_string(), "127.0.0.1:50051".parse().unwrap());
+        map.insert("story-engine".to_string(), "127.0.0.1:50052".parse().unwrap());
+        Self { services: map }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -351,6 +373,7 @@ impl Default for FinalverseConfig {
             performance: PerformanceConfig::default(),
             monitoring: MonitoringConfig::default(),
             game: GameConfig::default(),
+            grpc_services: GrpcServiceRegistry::default(),
         }
     }
 }

--- a/config/src/main.rs
+++ b/config/src/main.rs
@@ -1,0 +1,25 @@
+use axum::{routing::get, Router, Json};
+use finalverse_config::{load_default_config, GrpcServiceRegistry};
+use std::sync::Arc;
+use std::net::SocketAddr;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt::init();
+    let config = load_default_config()?;
+    let registry = Arc::new(config.grpc_services);
+    let app = Router::new().route(
+        "/services/grpc",
+        get({
+            let registry = registry.clone();
+            move || async move { Json(registry.services.clone()) }
+        }),
+    );
+    let addr: SocketAddr = std::env::var("FINALVERSE_CONFIG_ADDR")
+        .unwrap_or_else(|_| "0.0.0.0:7070".to_string())
+        .parse()?;
+    println!("finalverse-config listening on {}", addr);
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+    axum::serve(listener, app).await?;
+    Ok(())
+}

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -17,6 +17,7 @@ tokio.workspace = true
 tokio-tungstenite = "0.26.2"
 reqwest.workspace = true
 finalverse-plugin = { path = "../services/plugin" }
+once_cell.workspace = true
 
 [[bin]]
 name = "finalverse-server"

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -36,6 +36,7 @@ use tokio::{
 use tokio_tungstenite::{accept_async, tungstenite::Message};
 use finalverse_plugin::{discover_plugins, LoadedPlugin, ServicePlugin};
 use finalverse_service_registry::LocalServiceRegistry;
+mod mesh;
 use crate::{ServiceInfo, ServiceStatus, LogEntry, LogLevel, ServerCommand, ServerResponse};
 use tonic::transport::Server as GrpcServer;
 
@@ -682,6 +683,8 @@ async fn main() -> Result<()> {
     for p in &plugins {
         p.instance.init(&registry).await?;
     }
+
+    mesh::spawn_refresh_task();
 
     // gRPC server aggregating plugin services
     let grpc_port: u16 = std::env::var("FINALVERSE_GRPC_PORT")

--- a/server/src/mesh.rs
+++ b/server/src/mesh.rs
@@ -1,0 +1,65 @@
+use std::{collections::HashMap, net::SocketAddr, sync::Arc, time::Duration};
+use tokio::sync::RwLock;
+use tonic::transport::{Channel, Endpoint};
+use uuid::Uuid;
+use anyhow::Result;
+use once_cell::sync::Lazy;
+
+#[derive(Debug, Clone)]
+pub struct MeshContext {
+    pub request_id: Uuid,
+    pub peer_cert: Option<String>,
+    pub trace_id: Uuid,
+}
+
+#[derive(Clone, Default)]
+pub struct GrpcAddressBook {
+    inner: Arc<RwLock<HashMap<String, SocketAddr>>>,
+}
+
+impl GrpcAddressBook {
+    pub fn new() -> Self {
+        Self { inner: Arc::new(RwLock::new(HashMap::new())) }
+    }
+    pub async fn update(&self, map: HashMap<String, SocketAddr>) {
+        let mut guard = self.inner.write().await;
+        *guard = map;
+    }
+    pub async fn get(&self, name: &str) -> Option<SocketAddr> {
+        self.inner.read().await.get(name).cloned()
+    }
+}
+
+pub static ADDRESS_BOOK: Lazy<GrpcAddressBook> = Lazy::new(GrpcAddressBook::new);
+
+pub async fn dial(service_name: &str) -> Result<Channel> {
+    let addr = ADDRESS_BOOK
+        .get(service_name)
+        .await
+        .ok_or_else(|| anyhow::anyhow!("unknown service: {service_name}"))?;
+    let endpoint = Endpoint::from_shared(format!("http://{}", addr))?;
+    Ok(endpoint.connect().await?)
+}
+
+pub fn spawn_refresh_task() {
+    let book = ADDRESS_BOOK.clone();
+    tokio::spawn(async move {
+        loop {
+            if let Ok(map) = fetch_address_book().await {
+                book.update(map).await;
+            }
+            tokio::time::sleep(Duration::from_secs(30)).await;
+        }
+    });
+}
+
+async fn fetch_address_book() -> Result<HashMap<String, SocketAddr>> {
+    let base = std::env::var("FINALVERSE_CONFIG_URL")
+        .unwrap_or_else(|_| "http://localhost:7070".to_string());
+    let resp = reqwest::get(format!("{}/services/grpc", base)).await?;
+    let raw: HashMap<String, String> = resp.json().await?;
+    raw.into_iter()
+        .map(|(k, v)| v.parse().map(|a| (k, a)))
+        .collect::<std::result::Result<_, _>>()
+        .map_err(|e| anyhow::anyhow!(e))
+}

--- a/services/realtime-gateway/Cargo.toml
+++ b/services/realtime-gateway/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "finalverse-realtime-gateway"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+axum.workspace = true
+tokio.workspace = true
+futures = "0.3"
+libloading = { version = "0.7", optional = true }
+tracing.workspace = true
+async-trait = "0.1"
+anyhow.workspace = true
+
+[features]
+dynamic = ["libloading"]
+
+[[bin]]
+name = "finalverse-realtime-gateway"
+path = "src/main.rs"

--- a/services/realtime-gateway/src/lib.rs
+++ b/services/realtime-gateway/src/lib.rs
@@ -1,0 +1,60 @@
+use axum::extract::ws::WebSocket;
+use std::future::Future;
+
+#[async_trait::async_trait]
+pub trait WebSocketPlugin: Send + Sync {
+    fn register_ws_path(&self) -> &'static str;
+    async fn handle(&self, socket: WebSocket);
+}
+
+#[cfg(feature = "dynamic")]
+use libloading::{Library, Symbol};
+
+pub struct LoadedPlugin {
+    pub instance: Box<dyn WebSocketPlugin>,
+    #[cfg(feature = "dynamic")]
+    _lib: Library,
+}
+
+impl LoadedPlugin {
+    pub fn take(&mut self) -> Box<dyn WebSocketPlugin> {
+        std::mem::replace(&mut self.instance, Box::new(Dummy))
+    }
+}
+
+struct Dummy;
+#[async_trait::async_trait]
+impl WebSocketPlugin for Dummy {
+    fn register_ws_path(&self) -> &'static str { "_dummy" }
+    async fn handle(&self, _socket: WebSocket) {}
+}
+
+pub async fn discover_plugins(dir: &std::path::Path) -> Vec<LoadedPlugin> {
+    let mut plugins = Vec::new();
+    if let Ok(entries) = std::fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if let Some(ext) = path.extension() {
+                if ext == "so" || ext == "dylib" || ext == "dll" {
+                    if let Ok(p) = unsafe { load_plugin(&path) } {
+                        plugins.push(p);
+                    }
+                }
+            }
+        }
+    }
+    plugins
+}
+
+#[cfg(feature = "dynamic")]
+unsafe fn load_plugin(path: &std::path::Path) -> anyhow::Result<LoadedPlugin> {
+    let lib = Library::new(path)?;
+    let constructor: Symbol<unsafe extern "C" fn() -> *mut dyn WebSocketPlugin> = lib.get(b"finalverse_ws_plugin")?;
+    let raw = constructor();
+    Ok(LoadedPlugin { instance: Box::from_raw(raw), _lib: lib })
+}
+
+#[cfg(not(feature = "dynamic"))]
+unsafe fn load_plugin(_path: &std::path::Path) -> anyhow::Result<LoadedPlugin> {
+    anyhow::bail!("dynamic plugin loading disabled")
+}

--- a/services/realtime-gateway/src/main.rs
+++ b/services/realtime-gateway/src/main.rs
@@ -1,0 +1,29 @@
+use axum::{routing::get, extract::ws::WebSocketUpgrade, Router};
+use axum::extract::ws::WebSocket;
+use finalverse_realtime_gateway::{discover_plugins, LoadedPlugin};
+use std::path::PathBuf;
+use tracing::info;
+
+async fn handle_socket(mut plugin: Box<dyn finalverse_realtime_gateway::WebSocketPlugin>, ws: WebSocketUpgrade) -> impl axum::response::IntoResponse {
+    ws.on_upgrade(move |socket| async move {
+        plugin.handle(socket).await;
+    })
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt::init();
+    let dir = PathBuf::from("./realtime-plugins");
+    let mut plugins = discover_plugins(&dir).await;
+    let mut app = Router::new();
+    for p in &mut plugins {
+        let mut instance = p.take();
+        let path = instance.register_ws_path();
+        app = app.route(path, get(move |ws: WebSocketUpgrade| handle_socket(instance, ws)));
+    }
+    let addr = "0.0.0.0:8081";
+    info!("Realtime gateway listening on {}", addr);
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+    axum::serve(listener, app).await?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- introduce `GrpcServiceRegistry` in config crate
- expose HTTP endpoint `/services/grpc` via new `finalverse-config` binary
- implement mesh support in server with periodic registry refresh
- wire mesh refresh in server startup
- add new `finalverse-realtime-gateway` service with plugin-based websocket handlers

## Testing
- `cargo check` *(fails: download of crates.io index blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68491d93ffd88332b6416fc502380057