### PR TITLE
Fix plugin crate dependencies

### DIFF
--- a/crates/plugin/Cargo.toml
+++ b/crates/plugin/Cargo.toml
@@ -10,6 +10,8 @@ tonic.workspace = true
 async-trait.workspace = true
 tracing.workspace = true
 libloading = { workspace = true, optional = true }
+anyhow.workspace = true
+service-registry.workspace = true
 
 [features]
 dynamic = ["libloading"]

--- a/crates/plugin/src/lib.rs
+++ b/crates/plugin/src/lib.rs
@@ -7,7 +7,10 @@ use std::path::{Path, PathBuf};
 #[cfg(feature = "dynamic")]
 use libloading::{Library, Symbol};
 
+// Import the registry from the workspace `service_registry` crate (formerly
+// `finalverse_service_registry`)
 use service_registry::LocalServiceRegistry;
+// Use anyhow's Result for convenience in async plugin APIs
 use anyhow::Result;
 
 /// Trait implemented by optional service plugins.


### PR DESCRIPTION
## Summary
- include `anyhow` and `service-registry` in the plugin crate
- clarify service registry import to match renamed crate

## Testing
- `cargo check -p plugin` *(fails: failed to download from crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_684981499e208332bb871a6dffb012b7