### PR TITLE
Add object-safe event bus

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ serde_json = "1.0"
 prost = "0.12"
 tonic = "0.11"
 tonic-build = "0.13.1"
+tonic-health = "0.10"
 
 # Database
 sqlx = { version = "0.7", features = ["runtime-tokio-rustls", "postgres", "uuid", "chrono"] }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -20,6 +20,7 @@ fv-plugin.workspace = true
 once_cell.workspace = true
 uuid = { workspace = true, features = ["v4"] }
 tonic.workspace = true
+tonic-health.workspace = true
 
 service-registry.workspace = true
 futures-util = "0.3.31"

--- a/services/story-engine/src/main.rs
+++ b/services/story-engine/src/main.rs
@@ -62,11 +62,13 @@ impl SongEngineService {
         let songs = self.active_songs.clone();
         let event_bus = self.event_bus.clone();
 
-        let harmony_sub_id = self.event_bus.subscribe("events.harmony", move |event| {
-            let songs = songs.clone();
-            let event_bus = event_bus.clone();
+        let harmony_sub_id = self
+            .event_bus
+            .subscribe("events.harmony", Box::new(move |event| {
+                let songs = songs.clone();
+                let event_bus = event_bus.clone();
 
-            tokio::spawn(async move {
+                tokio::spawn(async move {
                 if let EventType::Harmony(harmony_event) = &event.event_type {
                     match harmony_event {
                         HarmonyEvent::AttunementAchieved { player_id, tier, .. } => {
@@ -105,7 +107,8 @@ impl SongEngineService {
                     }
                 }
             });
-        }).await?;
+            }))
+            .await?;
 
         self.subscription_ids.write().await.push(harmony_sub_id);
 


### PR DESCRIPTION
## Summary
- make `GameEventBus` trait object safe by removing generics on `subscribe` methods
- adjust LocalEventBus and NatsEventBus to match new API
- update integration tests and services for new `subscribe` signature
- pass plugin instances when registering gRPC services

## Testing
- `cargo check -p finalverse-server` *(failed: could not download crates)*

------
https://chatgpt.com/codex/tasks/task_e_684ae3da8fe483329568b8c6cbd2c435