### PR TITLE
Fix plugin gRPC builder interface

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,3 +122,6 @@ warp = "0.3"
 libloading = "0.7"
 wasmtime = "13"
 
+[patch.crates-io]
+tonic = "0.11"
+

--- a/crates/fv-plugin/src/lib.rs
+++ b/crates/fv-plugin/src/lib.rs
@@ -1,7 +1,7 @@
 // services/plugin/src/lib.rs
 // Dynamic service plugin interface for Finalverse
-use axum::Router;
-use tonic::transport::Server;
+use axum::Router as AxumRouter;
+use tonic::transport::server::Router as GrpcRouter;
 use std::path::{Path, PathBuf};
 
 #[cfg(feature = "dynamic")]
@@ -21,7 +21,7 @@ pub trait ServicePlugin: Send + Sync {
     fn name(&self) -> &'static str;
 
     /// Build the router for this plugin.
-    async fn routes(&self) -> Router;
+    async fn routes(&self) -> AxumRouter;
 
     /// Initialize the plugin. Called after loading so the plugin can register
     /// itself with the service registry or load configuration.
@@ -33,7 +33,7 @@ pub trait ServicePlugin: Send + Sync {
     /// Implementations can add their own gRPC service definitions and return
     /// the updated builder. The default implementation simply returns the
     /// builder unchanged.
-    fn register_grpc(self: Box<Self>, server: Server) -> Server {
+    fn register_grpc(self: Box<Self>, server: GrpcRouter) -> GrpcRouter {
         server
     }
 }
@@ -44,8 +44,8 @@ pub struct NoopPlugin;
 #[async_trait::async_trait]
 impl ServicePlugin for NoopPlugin {
     fn name(&self) -> &'static str { "noop" }
-    async fn routes(&self) -> Router { Router::new() }
-    fn register_grpc(self: Box<Self>, server: Server) -> Server { server }
+    async fn routes(&self) -> AxumRouter { AxumRouter::new() }
+    fn register_grpc(self: Box<Self>, server: GrpcRouter) -> GrpcRouter { server }
 }
 
 /// Discover available plugins on the filesystem at runtime.

--- a/plugins/greeter-plugin/src/lib.rs
+++ b/plugins/greeter-plugin/src/lib.rs
@@ -2,8 +2,8 @@
 use async_trait::async_trait;
 use fv_plugin::ServicePlugin;
 use service_registry::LocalServiceRegistry;
-use axum::Router;
-use tonic::transport::Server;
+use axum::Router as AxumRouter;
+use tonic::transport::server::Router as GrpcRouter;
 use serde_json::Value;
 use serde::de::Error as SerdeError;
 use std::sync::Arc;
@@ -59,9 +59,9 @@ impl ServicePlugin for GreeterPlugin {
         "greeter"
     }
 
-    async fn routes(&self) -> Router {
+    async fn routes(&self) -> AxumRouter {
         // In a real plugin we would expose HTTP routes here.
-        Router::new()
+        AxumRouter::new()
     }
 
     async fn init(&self, _registry: &LocalServiceRegistry) -> anyhow::Result<()> {
@@ -69,7 +69,7 @@ impl ServicePlugin for GreeterPlugin {
         Ok(())
     }
 
-    fn register_grpc(self: Box<Self>, server: Server) -> Server {
+    fn register_grpc(self: Box<Self>, server: GrpcRouter) -> GrpcRouter {
         server
     }
 }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -700,17 +700,17 @@ async fn main() -> Result<()> {
     tokio::spawn(async move {
         // Build the gRPC server with all plugin services
         let (_health_reporter, health_service) = health_reporter();
-        let mut builder = GrpcServer::builder().add_service(health_service);
+        let mut router = GrpcServer::builder().add_service(health_service);
 
         // Register each plugin's gRPC services
         for mut plugin in grpc_plugins {
             let instance = plugin.take_instance();
-            builder = instance.register_grpc(builder);
+            router = instance.register_grpc(router);
         }
 
         println!("🚀 Starting gRPC server on {}", grpc_addr);
 
-        if let Err(e) = builder.serve(grpc_addr).await {
+        if let Err(e) = router.serve(grpc_addr).await {
             eprintln!("❌ gRPC server error: {}", e);
         }
     });

--- a/services/harmony-service/src/main.rs
+++ b/services/harmony-service/src/main.rs
@@ -302,7 +302,8 @@ async fn main() -> anyhow::Result<()> {
     service.start_event_listeners().await?;
 
     // Define routes
-    let service_filter = warp::any().map(move || service.clone());
+    let service_clone = service.clone();
+    let service_filter = warp::any().map(move || service_clone.clone());
 
     let add_resonance = warp::path!("resonance" / String / String / f64)
         .and(warp::post())


### PR DESCRIPTION
## Summary
- unify gRPC server builder handling
- adjust `ServicePlugin` trait for `tonic` 0.11 router
- update Greeter plugin for new trait
- pin single `tonic` version across workspace

## Testing
- `cargo fmt` *(failed: rustfmt missing)*
- `cargo check --workspace` *(failed: cannot download crates)*

------
https://chatgpt.com/codex/tasks/task_e_684af76722e083329a54e39a8a11681c