### PR TITLE
Move world-engine service and fix build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "services/song-engine",
     "services/story-engine",
     "services/symphony-engine",
+    "services/world-engine",
     "services/websocket-gateway",
     "plugins/greeter-plugin",
     

--- a/crates/world-engine/Cargo.toml
+++ b/crates/world-engine/Cargo.toml
@@ -21,6 +21,3 @@ env_logger = "0.11.8"
 finalverse-audio-core.workspace = true
 redis.workspace = true
 
-[[bin]]
-name = "world-engine"
-path = "src/bin/world-engine.rs"

--- a/services/story-engine/Cargo.toml
+++ b/services/story-engine/Cargo.toml
@@ -30,3 +30,4 @@ anyhow = "1.0.98"
 env_logger = "0.11.8"
 finalverse-audio-core.workspace = true
 redis.workspace = true
+nalgebra.workspace = true

--- a/services/symphony-engine/Cargo.toml
+++ b/services/symphony-engine/Cargo.toml
@@ -25,7 +25,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 tracing.workspace = true
 tracing-subscriber = "0.3"
-nalgebra = "0.33.1"
+nalgebra.workspace = true
 rand = "0.8.5"
 
 [build-dependencies]

--- a/services/symphony-engine/src/audio_generator.rs
+++ b/services/symphony-engine/src/audio_generator.rs
@@ -1,19 +1,13 @@
 // services/symphony-engine/src/audio_generator.rs
 use finalverse_audio_core::*;
-use rodio::{OutputStream, Sink, Source};
-use std::sync::Arc;
+use rodio::{Sink, Source};
 use std::time::Duration;
 
-pub struct AudioGenerator {
-    output_stream: OutputStream,
-}
+pub struct AudioGenerator;
 
 impl AudioGenerator {
     pub fn new() -> Self {
-        let (stream, stream_handle) = OutputStream::try_default().unwrap();
-        Self {
-            output_stream: stream,
-        }
+        Self {}
     }
 
     pub async fn generate_ambient_track(&self, theme: MusicalTheme) -> AudioStream {
@@ -170,7 +164,7 @@ impl AudioGenerator {
         let len = layers[0].len();
         let mut mixed = vec![0.0; len];
 
-        for layer in layers {
+        for layer in &layers {
             for (i, &sample) in layer.iter().enumerate() {
                 mixed[i] += sample / layers.len() as f32;
             }

--- a/services/symphony-engine/src/main.rs
+++ b/services/symphony-engine/src/main.rs
@@ -75,7 +75,7 @@ impl SymphonyEngine {
             pubsub.subscribe("player:actions").await.unwrap();
             pubsub.subscribe("npc:events").await.unwrap();
 
-            while let Ok(msg) = pubsub.on_message().next().await {
+            while let Some(msg) = pubsub.on_message().next().await {
                 let payload: String = msg.get_payload().unwrap();
                 if let Ok(event) = serde_json::from_str::<AudioEvent>(&payload) {
                     // Process audio event
@@ -91,9 +91,8 @@ impl SymphonyEngine {
     async fn start_ambient_generator(&self) -> Result<(), Box<dyn std::error::Error>> {
         let world_state = self.world_state.clone();
         let music_ai = self.music_ai.clone();
-        let audio_gen = self.audio_generator.clone();
-
         tokio::spawn(async move {
+            let audio_gen = AudioGenerator::new();
             let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(30));
 
             loop {

--- a/services/symphony-engine/src/music_ai.rs
+++ b/services/symphony-engine/src/music_ai.rs
@@ -81,7 +81,7 @@ impl MusicAI {
         emotion: EmotionalState,
     ) -> MusicalTheme {
         // Character-specific theme generation
-        let base_instruments = match character.character_type {
+        let base_instruments = match &character.character_type {
             CharacterType::Echo(echo_type) => match echo_type {
                 EchoType::Lumi => vec![
                     Instrument::CrystalBells,
@@ -115,8 +115,8 @@ impl MusicAI {
             ],
         };
 
-        let mood = self.emotion_to_mood(emotion);
-        let scale = self.emotion_to_scale(emotion);
+        let mood = self.emotion_to_mood(emotion.clone());
+        let scale = self.emotion_to_scale(emotion.clone());
         let tempo = self.emotion_to_tempo(emotion);
 
         MusicalTheme {

--- a/services/symphony-engine/src/voice_synthesis.rs
+++ b/services/symphony-engine/src/voice_synthesis.rs
@@ -102,7 +102,10 @@ impl VoiceSynthesizer {
         let phonemes = self.text_to_melodic_phonemes(text, &adjusted_profile, &context);
 
         // Generate audio
-        let audio_data = self.tts_engine.synthesize(phonemes, adjusted_profile).await?;
+        let audio_data = self
+            .tts_engine
+            .synthesize(phonemes, adjusted_profile.clone())
+            .await?;
 
         // Apply character-specific effects
         let processed_audio = self.apply_character_effects(
@@ -243,7 +246,7 @@ impl VoiceSynthesizer {
     fn add_sparkle_effect(&self, audio: Vec<f32>) -> Vec<f32> {
         // Add high-frequency shimmer
         let mut output = audio.clone();
-        let mut phase = 0.0;
+        let mut phase: f32 = 0.0;
 
         for sample in &mut output {
             phase += 0.1;

--- a/services/world-engine/Cargo.toml
+++ b/services/world-engine/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "world-engine"
+version.workspace = true
+edition.workspace = true
+
+[[bin]]
+name = "world-engine"
+path = "src/main.rs"
+
+[dependencies]
+finalverse-world-engine = { path = "../../crates/world-engine" }
+finalverse-audio-core.workspace = true
+redis.workspace = true
+serde_json.workspace = true
+chrono.workspace = true
+uuid.workspace = true
+nalgebra.workspace = true
+async-trait = "0.1.88"
+tokio.workspace = true
+warp = "0.3.7"
+env_logger = "0.11.8"
+

--- a/services/world-engine/src/main.rs
+++ b/services/world-engine/src/main.rs
@@ -1,7 +1,7 @@
 // crates/world-engine/src/bin/world-engine.rs
 use std::sync::Arc;
 use tokio::time::{interval, Duration};
-use world_engine::{WorldEngine, Observer, WorldEvent, RegionState, RegionId, TerrainType, WeatherState, WeatherType, ecosystem::Species};
+use finalverse_world_engine::{WorldEngine, Observer, WorldEvent, RegionState, RegionId, TerrainType, WeatherState, WeatherType, ecosystem::Species};
 use finalverse_audio_core::{AudioEvent, AudioEventType, AudioSource};
 use nalgebra::Vector3;
 use redis::Client as RedisClient;


### PR DESCRIPTION
## Summary
- move the world-engine binary from `crates` to new `services/world-engine`
- align dependencies for `nalgebra` across services
- fix borrow and type issues in `symphony-engine`
- adjust story-engine dependency

## Testing
- `cargo check` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_684c26f4a91c8332be53aae2a7f2e615