### PR TITLE
Fix command handler channel

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,7 @@ nalgebra = { version = "0.32", features = ["serde-serialize"] }
 uuid = { version = "1.6", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 rand = "0.8"
-sysinfo = { version = "0.35.2", features = ["process"] }
+sysinfo = "0.35.2"
 
 # Finalverse internal crates
 finalverse-world3d = { path = "crates/world3d" }


### PR DESCRIPTION
## Summary
- use a bounded `mpsc` channel so the command handler future is `Send`
- store spawned child PIDs as `Option<u32>` directly

## Testing
- `cargo metadata --all-features --format-version 1 --no-deps`
- `cargo check -p finalverse-server` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_684d7496ea8c83328b7316144ae61d85