### PR TITLE
Unify RegionId type across modules

### DIFF
--- a/crates/core/src/types.rs
+++ b/crates/core/src/types.rs
@@ -1,14 +1,6 @@
 use serde::{Deserialize, Serialize};
-use uuid::Uuid;
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct PlayerId(pub String);
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct RegionId(pub String);
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct EchoId(pub String);
+// Re-export identifier types from the crate root to keep a single definition
+pub use crate::{PlayerId, RegionId, EchoId};
 
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub struct Coordinates {

--- a/crates/metabolism/src/lib.rs
+++ b/crates/metabolism/src/lib.rs
@@ -3,27 +3,8 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
-pub struct RegionId(pub String);
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum TerrainType {
-    Forest,
-    Desert,
-    Mountain,
-    Ocean,
-    Plains,
-    Corrupted,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum WeatherType {
-    Clear,
-    Cloudy,
-    Rain,
-    Storm,
-    DissonanceStorm,
-}
+// Use shared domain types from finalverse-core
+pub use finalverse_core::{RegionId, TerrainType, WeatherType};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WeatherState {

--- a/services/world-engine/src/lib.rs
+++ b/services/world-engine/src/lib.rs
@@ -12,7 +12,7 @@ pub use world::{WorldEngine, WorldState, WorldUpdate, WorldTime};
 
 // Re-export other important types
 pub use finalverse_ecosystem::{EcosystemSimulator, Species, SpeciesProfile, MigrationPhase};
-pub use finalverse_metobolism::{MetabolismSimulator, RegionId, RegionState, TerrainType, WeatherState, WeatherType};
+pub use finalverse_metobolism::{MetabolismSimulator, RegionState, WeatherState};
 
 
 // Core types that are shared across modules

--- a/services/world-engine/src/server.rs
+++ b/services/world-engine/src/server.rs
@@ -11,11 +11,12 @@ pub async fn region_handler(
     id: String,
     engine: Arc<WorldEngine>,
 ) -> Result<impl warp::Reply, warp::Rejection> {
-    if let Some(region) = engine.metabolism().get_region(&RegionId(id)).await {
-        Ok(warp::reply::json(&region))
-    } else {
-        Ok(warp::reply::json(&serde_json::json!({"error": "Region not found"})))
+    if let Ok(uuid) = uuid::Uuid::parse_str(&id) {
+        if let Some(region) = engine.metabolism().get_region(&RegionId(uuid)).await {
+            return Ok(warp::reply::json(&region));
+        }
     }
+    Ok(warp::reply::json(&serde_json::json!({"error": "Region not found"})))
 }
 
 pub async fn action_handler(


### PR DESCRIPTION
## Summary
- re-export `PlayerId`, `RegionId` and `EchoId` from the core crate in `types.rs`
- share `RegionId`, `TerrainType` and `WeatherType` from `finalverse-core` in the metabolism crate
- update world engine to use the unified types
- parse region ids as UUIDs in the world engine server

## Testing
- `cargo check --workspace --offline` *(fails: no matching package named `async-trait` found)*

------
https://chatgpt.com/codex/tasks/task_e_684dcc2cb4348332acf5cf2ba288b516