### PR TITLE
Implement WeatherType in core and remove duplicate

### DIFF
--- a/crates/core/src/events.rs
+++ b/crates/core/src/events.rs
@@ -1,4 +1,4 @@
-use crate::types::{Coordinates, EchoId, Melody, PlayerId, RegionId};
+use crate::types::{Coordinates, EchoId, Melody, PlayerId, RegionId, WeatherType};
 use serde::{Deserialize, Serialize};
 use chrono::{DateTime, Utc};
 
@@ -178,17 +178,6 @@ pub enum CelestialEventType {
     StarWhaleVisit,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum WeatherType {
-    Clear,
-    Cloudy,
-    Rain,
-    Storm,
-    Snow,
-    Fog,
-    HarmonyStorm, // Special Finalverse weather
-    SilenceMist,  // Corruption weather
-}
 
 impl FinalverseEvent {
     pub fn timestamp(&self) -> &DateTime<Utc> {

--- a/crates/core/src/types.rs
+++ b/crates/core/src/types.rs
@@ -63,6 +63,10 @@ pub enum WeatherType {
     Rain,
     Storm,
     DissonanceStorm,
+    Snow,
+    Fog,
+    HarmonyStorm,
+    SilenceMist,
 }
 
 impl Default for Coordinates {


### PR DESCRIPTION
## Summary
- extend `WeatherType` enum with full set of variants in `finalverse-core`
- use this enum in `events` module instead of defining a second one

## Testing
- `cargo check --workspace --locked --offline` *(fails: no matching package named `async-trait` found)*
- `cargo check --workspace --locked` *(fails to access crates.io due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_684dcfa57c20833281d17eb30204fd19