### PR TITLE
Fix EchoType usage and imports

### DIFF
--- a/crates/core/src/character.rs
+++ b/crates/core/src/character.rs
@@ -1,5 +1,6 @@
 // crates/finalverse-core/src/character.rs
-use crate::types::{Position, Uuid};
+use crate::types::Coordinates as Position;
+use uuid::Uuid;
 use crate::echo::{Echo, InteractionRecord};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -117,7 +118,7 @@ pub enum MelodyEffect {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum TargetType {
-Self,
+SelfTarget,
 Single,
 Area { radius: f32 },
 Group { max_targets: u32 },

--- a/crates/core/src/echo.rs
+++ b/crates/core/src/echo.rs
@@ -1,5 +1,7 @@
 // crates/core/src/echo.rs
-use crate::types::{EchoType, Position, Uuid};
+use crate::types::EchoType;
+use crate::types::Coordinates as Position;
+use uuid::Uuid;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 

--- a/crates/core/src/types.rs
+++ b/crates/core/src/types.rs
@@ -118,7 +118,7 @@ impl Note {
 }
 
 // Echo-specific types
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub enum EchoType {
     Lumi, // Hope & Discovery
     KAI,  // Logic & Understanding

--- a/services/echo-engine/src/main.rs
+++ b/services/echo-engine/src/main.rs
@@ -7,8 +7,9 @@ use axum::{
 };
 use finalverse_core::{
     echo::{Echo, EchoPersonality, EchoState},
-    types::{EchoType, Position, Uuid},
+    types::{EchoType, Coordinates as Position},
 };
+use uuid::Uuid;
 use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap,
@@ -76,10 +77,10 @@ async fn main() {
     let addr = SocketAddr::from(([0, 0, 0, 0], 3004));
     info!("Echo Engine listening on {}", addr);
 
-    axum::Server::bind(&addr)
-        .serve(app.into_make_service())
+    let listener = tokio::net::TcpListener::bind(addr)
         .await
-        .unwrap();
+        .expect("Failed to bind");
+    axum::serve(listener, app).await.unwrap();
 }
 
 fn initialize_first_echoes(state: &AppState) {


### PR DESCRIPTION
## Summary
- fix imports in core modules
- rename the invalid `Self` variant to `SelfTarget`
- mark `EchoType` as `Copy`
- fix unresolved imports in echo-engine service
- update axum server startup code

## Testing
- `cargo check -p finalverse-core --offline` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_684e6ee6d7748332a7d9beb113c3bbf2