### PR TITLE
Add basic Wasm host functions

### DIFF
--- a/crates/wasm-runtime/src/lib.rs
+++ b/crates/wasm-runtime/src/lib.rs
@@ -2,7 +2,7 @@
 // Runtime for loading and executing Wasm plugins safely
 use std::path::Path;
 use anyhow::{Context, Result};
-use wasmtime::{Engine, Func, Instance, Linker, Module, Store};
+use wasmtime::{Engine, Func, Instance, Linker, Module, Store, Caller, Memory};
 
 /// Context passed to Wasm plugins on events
 #[repr(C)]
@@ -29,7 +29,33 @@ impl WasmPlugin {
         let mut store = Store::new(&engine, ());
         let mut linker = Linker::new(&engine);
 
-        // TODO: register host functions (e.g. logging, memory access) here
+        // Basic host functions for plugins
+        linker.func_wrap("env", "log", |mut caller: Caller<'_, ()>, ptr: i32, len: i32| {
+            if let Some(memory) = caller.get_export("memory").and_then(|e| e.into_memory()) {
+                let mut buf = vec![0u8; len as usize];
+                if memory.read(&mut caller, ptr as usize, &mut buf).is_ok() {
+                    if let Ok(msg) = String::from_utf8(buf) {
+                        println!("[wasm] {}", msg);
+                    }
+                }
+            }
+        })?;
+
+        linker.func_wrap("env", "read_u8", |mut caller: Caller<'_, ()>, ptr: i32| -> i32 {
+            if let Some(memory) = caller.get_export("memory").and_then(|e| e.into_memory()) {
+                let mut byte = [0u8];
+                if memory.read(&mut caller, ptr as usize, &mut byte).is_ok() {
+                    return byte[0] as i32;
+                }
+            }
+            0
+        })?;
+
+        linker.func_wrap("env", "write_u8", |mut caller: Caller<'_, ()>, ptr: i32, val: i32| {
+            if let Some(memory) = caller.get_export("memory").and_then(|e| e.into_memory()) {
+                let _ = memory.write(&mut caller, ptr as usize, &[val as u8]);
+            }
+        })?;
 
         let instance = linker.instantiate(&mut store, &module)?;
         let call_on_event = instance

--- a/crates/wasm-runtime/tests/simple.rs
+++ b/crates/wasm-runtime/tests/simple.rs
@@ -1,0 +1,16 @@
+use finalverse_wasm_runtime::{EventContext, WasmPlugin};
+use std::path::Path;
+
+#[test]
+fn load_and_call() -> anyhow::Result<()> {
+    let plugin_path = Path::new("tests/simple_plugin.wat");
+    let mut plugin = WasmPlugin::load(plugin_path)?;
+    let ctx = EventContext {
+        entity_id: 1,
+        event_type: 0,
+        payload_ptr: std::ptr::null(),
+        payload_len: 0,
+    };
+    plugin.call_on_event(&ctx)?;
+    Ok(())
+}

--- a/crates/wasm-runtime/tests/simple_plugin.wat
+++ b/crates/wasm-runtime/tests/simple_plugin.wat
@@ -1,0 +1,10 @@
+(module
+  (import "env" "log" (func $log (param i32 i32)))
+  (import "env" "read_u8" (func $read (param i32) (result i32)))
+  (import "env" "write_u8" (func $write (param i32 i32)))
+  (memory (export "memory") 1)
+  (data (i32.const 0) "hello from wasm")
+  (func (export "on_event") (param i64)
+    i32.const 0
+    i32.const 15
+    call $log))


### PR DESCRIPTION
## Summary
- implement log/read/write host functions inside `WasmPlugin::load`
- expose these through the `Linker` before instantiation
- add simple Wasm test plugin demonstrating the new functions

## Testing
- `cargo test -p finalverse-wasm-runtime -- --nocapture` *(fails: failed to download from https://index.crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_684eba4883308332a45701e9b9d435b1