### PR TITLE
Fix world-engine grpc module build

### DIFF
--- a/services/world-engine/src/grpc/mod.rs
+++ b/services/world-engine/src/grpc/mod.rs
@@ -1,6 +1,5 @@
 // services/world-engine/src/grpc/mod.rs
 pub mod server;
-pub mod client;
 
 // Re-export proto types
 pub use finalverse_proto::world::*;


### PR DESCRIPTION
## Summary
- remove client module reference from world-engine gRPC mod.rs

## Testing
- `cargo check -p world-engine` *(fails: failed to download from crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_684f061852888332a84083ed8cdfaf8f