### PR TITLE
Stub local LLM provider and cleanup imports

### DIFF
--- a/services/ai-orchestra/src/main.rs
+++ b/services/ai-orchestra/src/main.rs
@@ -2,7 +2,7 @@ use axum::{
     extract::State,
     http::StatusCode,
     response::{IntoResponse, Json},
-    routing::{get, post},
+    routing::post,
     Router,
 };
 use finalverse_health::HealthMonitor;


### PR DESCRIPTION
## Summary
- remove unused imports in AI orchestra
- simplify `generate_local` with a placeholder implementation
- drop unused route helper in `main.rs`

## Testing
- `cargo check -p ai-orchestra` *(fails: Failed to fetch crates)*

------
https://chatgpt.com/codex/tasks/task_e_68504b094d40833280e15ec4edef6646