### PR TITLE
Fix gRPC conversions for RegionId

### DIFF
--- a/crates/metabolism/src/lib.rs
+++ b/crates/metabolism/src/lib.rs
@@ -61,4 +61,14 @@ impl MetabolismSimulator {
     pub async fn get_region(&self, id: &RegionId) -> Option<RegionState> {
         self.regions.read().await.get(id).cloned()
     }
+
+    pub async fn update_harmony(&self, id: &RegionId, delta: f64) -> Option<f64> {
+        let mut regions = self.regions.write().await;
+        if let Some(region) = regions.get_mut(id) {
+            region.harmony_level = (region.harmony_level + delta).clamp(0.0, 1.0);
+            Some(region.harmony_level)
+        } else {
+            None
+        }
+    }
 }

--- a/services/world-engine/src/lib.rs
+++ b/services/world-engine/src/lib.rs
@@ -3,6 +3,7 @@ pub mod grid_generation;
 pub mod world;
 
 pub mod server;
+pub mod grpc;
 
 use serde::{Deserialize, Serialize};
 pub use finalverse_core::{RegionId, TerrainType, WeatherType};

--- a/services/world-engine/src/world.rs
+++ b/services/world-engine/src/world.rs
@@ -187,4 +187,27 @@ impl WorldEngine {
     pub fn ecosystem(&self) -> Arc<EcosystemSimulator> {
         self.ecosystem.clone()
     }
+
+    pub async fn update_region_harmony(
+        &self,
+        region_id: &RegionId,
+        delta: f32,
+    ) -> anyhow::Result<HarmonyUpdateResult> {
+        let new_level = self
+            .metabolism
+            .update_harmony(region_id, delta as f64)
+            .await
+            .ok_or_else(|| anyhow::anyhow!("Region not found"))?;
+
+        Ok(HarmonyUpdateResult {
+            new_harmony_level: new_level as f32,
+            triggered_events: Vec::new(),
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct HarmonyUpdateResult {
+    pub new_harmony_level: f32,
+    pub triggered_events: Vec<WorldEvent>,
 }


### PR DESCRIPTION
## Summary
- expose grpc module from world-engine
- convert RegionId to/from uuid strings in gRPC server
- implement `update_region_harmony` in WorldEngine and MetabolismSimulator
- return strings for proto Region IDs

## Testing
- `cargo check -p world-engine` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_685067444bbc83328755eebf0edd8ff1