### PR TITLE
Move gRPC server to root

### DIFF
--- a/services/world-engine/src/grpc/mod.rs
+++ b/services/world-engine/src/grpc/mod.rs
@@ -1,5 +1,0 @@
-// services/world-engine/src/grpc/mod.rs
-pub mod server;
-
-// Re-export proto types
-pub use finalverse_proto::world::*;

--- a/services/world-engine/src/grpc_server.rs
+++ b/services/world-engine/src/grpc_server.rs
@@ -1,10 +1,12 @@
-// services/world-engine/src/grpc/server.rs
+// services/world-engine/src/grpc_server.rs
 use tonic::{Request, Response, Status};
 use std::sync::Arc;
 use std::collections::HashMap;
 use std::pin::Pin;
 use tokio::sync::RwLock;
 use tokio_stream::{wrappers::ReceiverStream, Stream, StreamExt};
+// Import types from the world_engine library so this module works
+// both when compiled as part of the library and the binary.
 use world_engine::{
     WorldEngine,
     RegionId,

--- a/services/world-engine/src/lib.rs
+++ b/services/world-engine/src/lib.rs
@@ -3,7 +3,7 @@ pub mod grid_generation;
 pub mod world;
 
 pub mod server;
-pub mod grpc;
+pub mod grpc_server;
 
 use serde::{Deserialize, Serialize};
 pub use finalverse_core::{RegionId, TerrainType, WeatherType};

--- a/services/world-engine/src/main.rs
+++ b/services/world-engine/src/main.rs
@@ -8,8 +8,8 @@ pub use world_engine::{
 };
 use finalverse_proto::world::world_service_server::WorldServiceServer;
 
-mod grpc;
-use grpc::server::WorldServiceImpl;
+mod grpc_server;
+use grpc_server::WorldServiceImpl;
 use finalverse_audio_core::{AudioEvent, AudioEventType, AudioSource};
 use nalgebra::Vector3;
 use redis::Client as RedisClient;


### PR DESCRIPTION
## Summary
- relocate gRPC server module to the crate root
- update module references after move

## Testing
- `cargo check -p world-engine --lib` *(fails: failed to download from crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_68507295d10c8332ad23ff7555914076