### PR TITLE
Introduce unified logging crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ members = [
     "crates/config",
     "crates/core",
     "crates/events",
+    "crates/logging",
     "crates/grpc-client",
     "crates/health",
     "crates/plugin",
@@ -120,6 +121,7 @@ finalverse-plugin = { path = "crates/plugin" }
 finalverse-wasm-runtime = { path = "crates/wasm-runtime" }
 finalverse-ecosystem = { path = "crates/ecosystem" }
 finalverse-metobolism = { path = "crates/metabolism" }
+finalverse-logging = { path = "crates/logging" }
 
 # QUIC/Networking
 quinn = "0.10"

--- a/README.md
+++ b/README.md
@@ -135,6 +135,12 @@ See [docs/plugin_dev_guide.md](docs/plugin_dev_guide.md) for details.
   server loads dynamic plugins from `FINALVERSE_PLUGIN_DIR` and exposes all
   gRPC services on `FINALVERSE_GRPC_PORT`. See `.env.example` for defaults.
 
+## Logging
+
+All services initialize logging via `finalverse-logging`.
+Set `FINALVERSE_LOG_LEVEL` (e.g. `info`, `debug`) to adjust verbosity.
+The format is controlled by `general.log_format` in `finalverse.toml`.
+
 ## Contributing
 
 This MVP focuses on the core loop of songweaving, world simulation and AI interaction. Contributions that enhance interoperability with FinalStorm, improve AI behaviours or extend the service APIs are welcome. Please ensure code is formatted with `cargo fmt` and that all services compile with `cargo build --workspace`.

--- a/crates/logging/Cargo.toml
+++ b/crates/logging/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "finalverse-logging"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+tracing.workspace = true
+tracing-subscriber.workspace = true
+finalverse-config.workspace = true
+once_cell.workspace = true

--- a/crates/logging/src/lib.rs
+++ b/crates/logging/src/lib.rs
@@ -1,0 +1,36 @@
+use std::sync::Once;
+use tracing_subscriber::{fmt, EnvFilter};
+use finalverse_config::{load_default_config, FinalverseConfig};
+
+static INIT: Once = Once::new();
+
+/// Initialize global logging subscriber.
+///
+/// `level` can override the default log level. If `None`, the
+/// `FINALVERSE_LOG_LEVEL` or `RUST_LOG` env vars are used, defaulting to `info`.
+/// The log format is chosen based on `FinalverseConfig::general.log_format`,
+/// falling back to `text` if configuration loading fails.
+pub fn init(level: Option<&str>) {
+    INIT.call_once(|| {
+        let config: Option<FinalverseConfig> = load_default_config().ok();
+        let log_level = level
+            .map(|s| s.to_string())
+            .or_else(|| std::env::var("FINALVERSE_LOG_LEVEL").ok())
+            .or_else(|| std::env::var("RUST_LOG").ok())
+            .unwrap_or_else(|| "info".to_string());
+        let env_filter = EnvFilter::new(log_level);
+
+        let log_format = config
+            .as_ref()
+            .map(|c| c.general.log_format.as_str())
+            .unwrap_or("text");
+
+        let subscriber_builder = fmt().with_env_filter(env_filter);
+        match log_format {
+            "json" => subscriber_builder.json().init(),
+            "pretty" => subscriber_builder.pretty().init(),
+            _ => subscriber_builder.init(),
+        }
+    });
+}
+

--- a/scripts/finalverse.sh
+++ b/scripts/finalverse.sh
@@ -228,7 +228,7 @@ start_service() {
     if [ "$USE_DOCKER" = "true" ]; then
         info "Starting $service in Docker on port $port..."
         docker build -f docker/Dockerfile.service --build-arg SERVICE="$service" -t "finalverse/$service" . > "$LOG_DIR/${service}.log" 2>&1 && \
-        docker run -d --name "$service" --network finalverse-network -p "$port:$port" "finalverse/$service" >> "$LOG_DIR/${service}.log" 2>&1
+        docker run -d --name "$service" --network finalverse-network -p "$port:$port" -e "FINALVERSE_LOG_LEVEL=${FINALVERSE_LOG_LEVEL:-info}" "finalverse/$service" >> "$LOG_DIR/${service}.log" 2>&1
         if [ $? -eq 0 ]; then
             success "$service container started (Port: $port)"
             return 0
@@ -244,7 +244,7 @@ start_service() {
         fi
 
         info "Starting $service on port $port..."
-        RUST_LOG=info target/release/$service > "$LOG_DIR/${service}.log" 2>&1 &
+        RUST_LOG="${FINALVERSE_LOG_LEVEL:-info}" target/release/$service > "$LOG_DIR/${service}.log" 2>&1 &
         local pid=$!
         echo $pid > "$LOG_DIR/${service}.pid"
 

--- a/services/ai-orchestra/Cargo.toml
+++ b/services/ai-orchestra/Cargo.toml
@@ -15,6 +15,7 @@ axum.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
+finalverse-logging.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 uuid.workspace = true

--- a/services/ai-orchestra/src/main.rs
+++ b/services/ai-orchestra/src/main.rs
@@ -8,6 +8,8 @@ use axum::{
 use finalverse_health::HealthMonitor;
 use service_registry::LocalServiceRegistry;
 use serde::{Deserialize, Serialize};
+use tracing::info;
+use finalverse_logging as logging;
 use std::{
     net::SocketAddr,
     sync::{Arc, RwLock},
@@ -229,7 +231,7 @@ async fn generate_world_description(
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tracing_subscriber::fmt::init();
+    logging::init(None);
     let state = Arc::new(RwLock::new(AIState::new()));
     let monitor = Arc::new(HealthMonitor::new("ai-orchestra", env!("CARGO_PKG_VERSION")));
     let registry = LocalServiceRegistry::new();
@@ -251,7 +253,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         );
 
     let addr = SocketAddr::from(([0, 0, 0, 0], 3004));
-    println!("AI Orchestra listening on {}", addr);
+    info!("AI Orchestra listening on {}", addr);
 
     let listener = tokio::net::TcpListener::bind(addr).await?;
     axum::serve(listener, app).await?;

--- a/services/api-gateway/Cargo.toml
+++ b/services/api-gateway/Cargo.toml
@@ -13,3 +13,4 @@ service-registry.workspace = true
 axum.workspace = true
 tokio.workspace = true
 serde = { workspace = true, features = ["derive"] }
+finalverse-logging.workspace = true

--- a/services/api-gateway/src/main.rs
+++ b/services/api-gateway/src/main.rs
@@ -3,9 +3,12 @@ use serde::{Deserialize, Serialize};
 use finalverse_health::HealthMonitor;
 use service_registry::LocalServiceRegistry;
 use std::{net::SocketAddr, sync::Arc};
+use tracing::info;
+use finalverse_logging as logging;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    logging::init(None);
     let monitor = Arc::new(HealthMonitor::new("api-gateway", env!("CARGO_PKG_VERSION")));
     let registry = LocalServiceRegistry::new();
     registry
@@ -17,7 +20,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .route("/login", post(login_handler));
 
     let addr = SocketAddr::from(([0, 0, 0, 0], 8080));
-    println!("API Gateway listening on {}", addr);
+    info!("API Gateway listening on {}", addr);
     let listener = tokio::net::TcpListener::bind(addr).await?;
     axum::serve(listener, app).await?;
     Ok(())

--- a/services/asset-service/Cargo.toml
+++ b/services/asset-service/Cargo.toml
@@ -10,3 +10,4 @@ finalverse-health.workspace = true
 service-registry.workspace = true
 axum.workspace = true
 tokio.workspace = true
+finalverse-logging.workspace = true

--- a/services/asset-service/src/main.rs
+++ b/services/asset-service/src/main.rs
@@ -2,9 +2,12 @@ use axum::Router;
 use finalverse_health::HealthMonitor;
 use service_registry::LocalServiceRegistry;
 use std::{net::SocketAddr, sync::Arc};
+use tracing::info;
+use finalverse_logging as logging;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    logging::init(None);
     let monitor = Arc::new(HealthMonitor::new("asset-service", env!("CARGO_PKG_VERSION")));
     let registry = LocalServiceRegistry::new();
     registry
@@ -14,7 +17,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let app = Router::new().merge(monitor.clone().axum_routes());
 
     let addr = SocketAddr::from(([0, 0, 0, 0], 3007));
-    println!("Asset Service listening on {}", addr);
+    info!("Asset Service listening on {}", addr);
     let listener = tokio::net::TcpListener::bind(addr).await?;
     axum::serve(listener, app).await?;
     Ok(())

--- a/services/behavior-ai/Cargo.toml
+++ b/services/behavior-ai/Cargo.toml
@@ -10,3 +10,4 @@ finalverse-health.workspace = true
 service-registry.workspace = true
 axum.workspace = true
 tokio.workspace = true
+finalverse-logging.workspace = true

--- a/services/behavior-ai/src/main.rs
+++ b/services/behavior-ai/src/main.rs
@@ -2,9 +2,12 @@ use axum::Router;
 use finalverse_health::HealthMonitor;
 use service_registry::LocalServiceRegistry;
 use std::{net::SocketAddr, sync::Arc};
+use tracing::info;
+use finalverse_logging as logging;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    logging::init(None);
     let monitor = Arc::new(HealthMonitor::new("behavior-ai", env!("CARGO_PKG_VERSION")));
     let registry = LocalServiceRegistry::new();
     registry
@@ -14,7 +17,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let app = Router::new().merge(monitor.clone().axum_routes());
 
     let addr = SocketAddr::from(([0, 0, 0, 0], 3011));
-    println!("Behavior AI listening on {}", addr);
+    info!("Behavior AI listening on {}", addr);
     let listener = tokio::net::TcpListener::bind(addr).await?;
     axum::serve(listener, app).await?;
     Ok(())

--- a/services/community/Cargo.toml
+++ b/services/community/Cargo.toml
@@ -10,3 +10,4 @@ finalverse-health.workspace = true
 service-registry.workspace = true
 axum.workspace = true
 tokio.workspace = true
+finalverse-logging.workspace = true

--- a/services/community/src/main.rs
+++ b/services/community/src/main.rs
@@ -2,9 +2,12 @@ use axum::Router;
 use finalverse_health::HealthMonitor;
 use service_registry::LocalServiceRegistry;
 use std::{net::SocketAddr, sync::Arc};
+use tracing::info;
+use finalverse_logging as logging;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    logging::init(None);
     let monitor = Arc::new(HealthMonitor::new("community", env!("CARGO_PKG_VERSION")));
     let registry = LocalServiceRegistry::new();
     registry
@@ -14,7 +17,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let app = Router::new().merge(monitor.clone().axum_routes());
 
     let addr = SocketAddr::from(([0, 0, 0, 0], 3008));
-    println!("Community Service listening on {}", addr);
+    info!("Community Service listening on {}", addr);
     let listener = tokio::net::TcpListener::bind(addr).await?;
     axum::serve(listener, app).await?;
     Ok(())

--- a/services/echo-engine/Cargo.toml
+++ b/services/echo-engine/Cargo.toml
@@ -14,6 +14,7 @@ axum.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
+finalverse-logging.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 uuid.workspace = true

--- a/services/echo-engine/src/main.rs
+++ b/services/echo-engine/src/main.rs
@@ -18,6 +18,7 @@ use std::{
 };
 use tower_http::trace::TraceLayer;
 use tracing::{info, Level};
+use finalverse_logging as logging;
 
 #[derive(Clone)]
 struct AppState {
@@ -54,9 +55,7 @@ impl From<&Echo> for EchoResponse {
 #[tokio::main]
 async fn main() {
     // Initialize tracing
-    tracing_subscriber::fmt()
-        .with_max_level(Level::INFO)
-        .init();
+    logging::init(Some("info"));
 
     let state = AppState {
         echoes: Arc::new(Mutex::new(HashMap::new())),

--- a/services/first-hour/Cargo.toml
+++ b/services/first-hour/Cargo.toml
@@ -20,6 +20,7 @@ anyhow.workspace = true
 image = "0.24.9"
 serde_json = "1.0.140"
 tracing-subscriber = "0.3.19"
+finalverse-logging.workspace = true
 maplit = "1"
 
 redis = { workspace = true, features = ["tokio-comp"] }

--- a/services/first-hour/src/main.rs
+++ b/services/first-hour/src/main.rs
@@ -1,10 +1,11 @@
 // services/first-hour/src/main.rs
 use first_hour::{FirstHourService, FirstHourConfig};
 use tracing::info;
+use finalverse_logging as logging;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    tracing_subscriber::fmt::init();
+    logging::init(None);
 
     info!("Starting First Hour Service...");
 

--- a/services/harmony-service/Cargo.toml
+++ b/services/harmony-service/Cargo.toml
@@ -16,6 +16,7 @@ finalverse-protocol.workspace = true
 axum.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
+finalverse-logging.workspace = true
 serde_json.workspace = true
 uuid.workspace = true
 chrono.workspace = true
@@ -23,7 +24,6 @@ finalverse-health.workspace = true
 service-registry.workspace = true
 warp.workspace = true
 async-trait = "0.1.88"
-env_logger.workspace = true
 serde = { workspace = true, features = ["derive"] }
 tokio = { workspace = true, features = ["full"] }
 

--- a/services/procedural-gen/Cargo.toml
+++ b/services/procedural-gen/Cargo.toml
@@ -13,6 +13,7 @@ tokio.workspace = true
 serde = { workspace = true, features = ["derive"] }
 tracing.workspace = true
 anyhow.workspace = true
+finalverse-logging.workspace = true
 
 [[bin]]
 name = "procedural-gen"

--- a/services/procedural-gen/src/main.rs
+++ b/services/procedural-gen/src/main.rs
@@ -2,9 +2,12 @@ use axum::Router;
 use finalverse_health::HealthMonitor;
 use service_registry::LocalServiceRegistry;
 use std::{net::SocketAddr, sync::Arc};
+use tracing::info;
+use finalverse_logging as logging;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    logging::init(None);
     let monitor = Arc::new(HealthMonitor::new("procedural-gen", env!("CARGO_PKG_VERSION")));
     let registry = LocalServiceRegistry::new();
     registry
@@ -14,7 +17,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let app = Router::new().merge(monitor.clone().axum_routes());
 
     let addr = SocketAddr::from(([0, 0, 0, 0], 3010));
-    println!("Procedural Gen listening on {}", addr);
+    info!("Procedural Gen listening on {}", addr);
     let listener = tokio::net::TcpListener::bind(addr).await?;
     axum::serve(listener, app).await?;
     Ok(())

--- a/services/realtime-gateway/Cargo.toml
+++ b/services/realtime-gateway/Cargo.toml
@@ -13,11 +13,11 @@ tracing.workspace = true
 async-trait.workspace = true
 anyhow.workspace = true
 tracing-subscriber.workspace = true
+finalverse-logging.workspace = true
 warp = "0.3.7"
 serde = { version = "1.0.219", features = ["derive"] }
 uuid = { version = "1.17.0", features = ["v4"] }
 serde_json = "1.0.140"
-env_logger = "0.11.8"
 dashmap = "7.0.0-rc2"
 
 [features]

--- a/services/realtime-gateway/src/main.rs
+++ b/services/realtime-gateway/src/main.rs
@@ -7,6 +7,8 @@ use warp::ws::{WebSocket, Message};
 use futures::{StreamExt, SinkExt};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
+use tracing::info;
+use finalverse_logging as logging;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ClientMessage {
@@ -154,7 +156,7 @@ async fn handle_websocket(
 
 #[tokio::main]
 async fn main() {
-    env_logger::init();
+    logging::init(None);
 
     let clients = Arc::new(ConnectionManager::new());
     let plugins = Arc::new(RwLock::new(PluginRegistry::new()));
@@ -174,7 +176,7 @@ async fn main() {
 
     let routes = ws_route.or(health_route);
 
-    println!("🌐 Realtime Gateway starting on port 3000");
+    info!("🌐 Realtime Gateway starting on port 3000");
     warp::serve(routes)
         .run(([0, 0, 0, 0], 3000))
         .await;
@@ -198,10 +200,10 @@ impl WebSocketPlugin for EchoPlugin {
     }
 
     async fn on_connect(&self, client_id: &str) {
-        println!("Client {} connected to echo plugin", client_id);
+        info!("Client {} connected to echo plugin", client_id);
     }
 
     async fn on_disconnect(&self, client_id: &str) {
-        println!("Client {} disconnected from echo plugin", client_id);
+        info!("Client {} disconnected from echo plugin", client_id);
     }
 }

--- a/services/silence-service/Cargo.toml
+++ b/services/silence-service/Cargo.toml
@@ -10,3 +10,4 @@ finalverse-health.workspace = true
 service-registry.workspace = true
 axum.workspace = true
 tokio.workspace = true
+finalverse-logging.workspace = true

--- a/services/silence-service/src/main.rs
+++ b/services/silence-service/src/main.rs
@@ -2,9 +2,12 @@ use axum::Router;
 use finalverse_health::HealthMonitor;
 use service_registry::LocalServiceRegistry;
 use std::{net::SocketAddr, sync::Arc};
+use tracing::info;
+use finalverse_logging as logging;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    logging::init(None);
     let monitor = Arc::new(HealthMonitor::new("silence-service", env!("CARGO_PKG_VERSION")));
     let registry = LocalServiceRegistry::new();
     registry
@@ -14,7 +17,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let app = Router::new().merge(monitor.clone().axum_routes());
 
     let addr = SocketAddr::from(([0, 0, 0, 0], 3009));
-    println!("Silence Service listening on {}", addr);
+    info!("Silence Service listening on {}", addr);
     let listener = tokio::net::TcpListener::bind(addr).await?;
     axum::serve(listener, app).await?;
     Ok(())

--- a/services/song-engine/Cargo.toml
+++ b/services/song-engine/Cargo.toml
@@ -14,6 +14,7 @@ axum.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
+finalverse-logging.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 uuid.workspace = true

--- a/services/song-engine/src/main.rs
+++ b/services/song-engine/src/main.rs
@@ -22,6 +22,8 @@ use tower_http::cors::CorsLayer;
 use uuid::Uuid;
 use finalverse_health::HealthMonitor;
 use service_registry::LocalServiceRegistry;
+use tracing::info;
+use finalverse_logging as logging;
 
 #[derive(Debug, Clone)]
 pub struct SongEngineState {
@@ -388,7 +390,7 @@ async fn process_song_event(
 
 #[tokio::main]
 async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
-    tracing_subscriber::fmt::init();
+    logging::init(None);
 
     let state = Arc::new(RwLock::new(SongEngineState::new()));
     let monitor = Arc::new(HealthMonitor::new("song-engine", env!("CARGO_PKG_VERSION")));
@@ -411,7 +413,7 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
         );
 
     let addr = SocketAddr::from(([0, 0, 0, 0], 3001));
-    println!("Song Engine listening on {}", addr);
+    info!("Song Engine listening on {}", addr);
 
     let listener = tokio::net::TcpListener::bind(addr).await?;
     axum::serve(listener, app).await?;

--- a/services/story-engine/Cargo.toml
+++ b/services/story-engine/Cargo.toml
@@ -27,7 +27,7 @@ tower.workspace = true
 tower-http = { workspace = true, features = ["cors"] }
 warp = "0.3.7"
 anyhow = "1.0.98"
-env_logger = "0.11.8"
+finalverse-logging.workspace = true
 finalverse-audio-core.workspace = true
 redis.workspace = true
 nalgebra.workspace = true

--- a/services/symphony-engine/Cargo.toml
+++ b/services/symphony-engine/Cargo.toml
@@ -25,6 +25,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 tracing.workspace = true
 tracing-subscriber = "0.3"
+finalverse-logging.workspace = true
 nalgebra.workspace = true
 rand = "0.8.5"
 tokio-stream = "0.1"

--- a/services/symphony-engine/src/main.rs
+++ b/services/symphony-engine/src/main.rs
@@ -4,6 +4,7 @@ use finalverse_config::{FinalverseConfig as Config, load_default_config};
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use tracing::{info, error};
+use finalverse_logging as logging;
 use tokio_stream::StreamExt;
 
 mod audio_generator;
@@ -123,7 +124,7 @@ impl SymphonyEngine {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tracing_subscriber::fmt::init();
+    logging::init(None);
 
     let config = load_default_config()?;
     let engine = SymphonyEngine::new(config).await?;

--- a/services/websocket-gateway/Cargo.toml
+++ b/services/websocket-gateway/Cargo.toml
@@ -18,6 +18,7 @@ tower-http = { workspace = true, features = ["cors"] }
 futures.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
+finalverse-logging.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 uuid.workspace = true

--- a/services/websocket-gateway/src/main.rs
+++ b/services/websocket-gateway/src/main.rs
@@ -14,6 +14,8 @@ use finalverse_core::{
 };
 use futures::{stream::SplitSink, stream::SplitStream, SinkExt, StreamExt};
 use serde::{Deserialize, Serialize};
+use tracing::info;
+use finalverse_logging as logging;
 use std::{
     collections::HashMap,
     net::SocketAddr,
@@ -190,7 +192,7 @@ async fn handle_message(
             interaction_type,
         } => {
             // Handle Echo interaction
-            println!(
+            info!(
                 "Player {} interacting with Echo {:?}: {}",
                 player_id.0, echo_id, interaction_type
             );
@@ -201,7 +203,7 @@ async fn handle_message(
 
 async fn send_to_song_engine(event: SongEvent) {
     // In a real implementation, this would send to the Song Engine service
-    println!("Sending to Song Engine: {:?}", event);
+    info!("Sending to Song Engine: {:?}", event);
 
     // For now, simulate with HTTP call
     let client = reqwest::Client::new();
@@ -214,7 +216,7 @@ async fn send_to_song_engine(event: SongEvent) {
     if let Ok(response) = response {
         if response.status().is_success() {
             if let Ok(data) = response.json::<serde_json::Value>().await {
-                println!("Song Engine response: {:?}", data);
+                info!("Song Engine response: {:?}", data);
             }
         }
     }
@@ -241,7 +243,7 @@ async fn broadcast_harmony_update(state: &SharedGameState, region: &RegionId, le
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tracing_subscriber::fmt::init();
+    logging::init(None);
 
     let state = Arc::new(RwLock::new(GameState::new()));
     let monitor = Arc::new(HealthMonitor::new("websocket-gateway", env!("CARGO_PKG_VERSION")));
@@ -261,7 +263,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         );
 
     let addr = SocketAddr::from(([0, 0, 0, 0], 3000));
-    println!("WebSocket Gateway listening on {}", addr);
+    info!("WebSocket Gateway listening on {}", addr);
 
     // Use axum::serve instead of the deprecated Server
     let listener = tokio::net::TcpListener::bind(addr).await?;

--- a/services/world-engine/Cargo.toml
+++ b/services/world-engine/Cargo.toml
@@ -37,7 +37,7 @@ tokio-stream.workspace = true
 async-trait = "0.1.88"
 tokio.workspace = true
 warp = "0.3.7"
-env_logger = "0.11.8"
+finalverse-logging.workspace = true
 anyhow = "1.0.98"
 
 [build-dependencies]

--- a/services/world3d-service/Cargo.toml
+++ b/services/world3d-service/Cargo.toml
@@ -13,3 +13,4 @@ tonic = "0.13.1"
 tracing = "0.1.41"
 anyhow = "1.0.98"
 tracing-subscriber = "0.3.19"
+finalverse-logging.workspace = true

--- a/services/world3d-service/src/main.rs
+++ b/services/world3d-service/src/main.rs
@@ -13,6 +13,7 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 use tonic::{transport::Server, Request, Response, Status};
 use tracing::{info, error};
+use finalverse_logging as logging;
 
 pub struct World3DService {
     world_manager: Arc<world_manager::WorldManager>,
@@ -57,7 +58,7 @@ impl World3DService {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    tracing_subscriber::fmt::init();
+    logging::init(None);
 
     let service = World3DService::new().await?;
     service.initialize_first_hour_world().await?;


### PR DESCRIPTION
## Summary
- add `finalverse-logging` crate
- switch every service to use the new logger and replace `println!` output with `tracing` macros
- allow log level to be configured in `finalverse.sh`
- document logging configuration in README

## Testing
- `cargo check -p finalverse-logging` *(fails: failed to download from crates.io)*
- `cargo fmt --all` *(fails: rustfmt component not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68519a3cce2483329fa013e511afc199