### PR TITLE
Add mapleai-agent crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ members = [
     "crates/proto",
     "crates/protocol",
     "crates/wasm-runtime",
+    "crates/mapleai-agent",
     "crates/ecosystem",
     "crates/world3d",
     
@@ -119,6 +120,7 @@ finalverse-server = { path = "server" }
 finalverse-config = { path = "crates/config" }
 finalverse-plugin = { path = "crates/plugin" }
 finalverse-wasm-runtime = { path = "crates/wasm-runtime" }
+mapleai-agent = { path = "crates/mapleai-agent" }
 finalverse-ecosystem = { path = "crates/ecosystem" }
 finalverse-metobolism = { path = "crates/metabolism" }
 finalverse-logging = { path = "crates/logging" }

--- a/crates/mapleai-agent/Cargo.toml
+++ b/crates/mapleai-agent/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "mapleai-agent"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+finalverse-protocol.workspace = true
+ai-orchestra = { path = "../../services/ai-orchestra" }
+async-trait.workspace = true
+tokio.workspace = true

--- a/crates/mapleai-agent/src/agent.rs
+++ b/crates/mapleai-agent/src/agent.rs
@@ -1,0 +1,111 @@
+use crate::{planner::Planner, llm_bridge::LLMBridge};
+use finalverse_protocol::{AgentState, ReasoningContext, BehaviorAction};
+use tokio::task::JoinHandle;
+
+#[derive(Clone)]
+pub struct Agent {
+    state: AgentState,
+    planner: Planner,
+    bridge: LLMBridge,
+}
+
+pub struct AgentHandle {
+    handle: JoinHandle<()>,
+}
+
+impl Agent {
+    pub fn new(id: String, region: String) -> Self {
+        Self {
+            state: AgentState {
+                id,
+                current_region: region,
+                last_action: None,
+                context: ReasoningContext {
+                    location: String::new(),
+                    nearby_entities: vec![],
+                    harmony_level: 0.5,
+                    tension: 0.0,
+                    memory: vec![],
+                },
+            },
+            planner: Planner::default(),
+            bridge: LLMBridge::new(),
+        }
+    }
+
+    pub fn state(&self) -> &AgentState {
+        &self.state
+    }
+
+    pub fn update_context(&mut self, ctx: ReasoningContext) {
+        self.state.context = ctx;
+    }
+
+    pub async fn step(&mut self) {
+        let action = self.planner.plan(&self.state.context);
+        self.state.last_action = Some(action);
+        let reasoning = self.bridge.reason(&self.state).await;
+        self.state.context.memory.push(reasoning);
+    }
+
+    pub fn spawn(mut self) -> AgentHandle {
+        let handle = tokio::spawn(async move {
+            loop {
+                self.step().await;
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+        });
+        AgentHandle { handle }
+    }
+}
+
+impl AgentHandle {
+    pub fn stop(self) {
+        self.handle.abort();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::llm_bridge::LLMEngine;
+    use ai_orchestra::{GenerationRequest, GenerationResponse};
+    use std::sync::Arc;
+
+    struct MockLLM;
+    #[async_trait::async_trait]
+    impl LLMEngine for MockLLM {
+        async fn generate(&self, _request: GenerationRequest) -> Result<GenerationResponse, Box<dyn std::error::Error + Send + Sync>> {
+            Ok(GenerationResponse { text: "ok".into(), model_used: "mock".into(), tokens_used: 1 })
+        }
+    }
+
+    #[tokio::test]
+    async fn test_agent_step_updates_action() {
+        let engine = Arc::new(MockLLM);
+        let mut agent = Agent {
+            state: AgentState {
+                id: "a".into(),
+                current_region: "r".into(),
+                last_action: None,
+                context: ReasoningContext { location: String::new(), nearby_entities: vec![], harmony_level: 1.0, tension: 0.0, memory: vec![] },
+            },
+            planner: Planner::default(),
+            bridge: LLMBridge::with_engine(engine),
+        };
+
+        agent.step().await;
+        assert!(agent.state.last_action.is_some());
+        assert_eq!(agent.state.context.memory.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_update_context() {
+        let mut agent = Agent::new("b".into(), "r".into());
+        let ctx = ReasoningContext { location: "loc".into(), nearby_entities: vec![], harmony_level: 0.1, tension: 0.8, memory: vec![] };
+        agent.update_context(ctx.clone());
+        assert_eq!(agent.state.context.location, "loc");
+        assert!((agent.state.context.harmony_level - 0.1).abs() < f32::EPSILON);
+        assert!((agent.state.context.tension - 0.8).abs() < f32::EPSILON);
+    }
+}

--- a/crates/mapleai-agent/src/lib.rs
+++ b/crates/mapleai-agent/src/lib.rs
@@ -1,0 +1,5 @@
+pub mod agent;
+pub mod planner;
+pub mod llm_bridge;
+
+pub use agent::{Agent, AgentHandle};

--- a/crates/mapleai-agent/src/llm_bridge.rs
+++ b/crates/mapleai-agent/src/llm_bridge.rs
@@ -1,0 +1,44 @@
+use std::sync::Arc;
+use async_trait::async_trait;
+use ai_orchestra::{LLMOrchestra, GenerationRequest, GenerationResponse};
+
+#[async_trait]
+pub trait LLMEngine: Send + Sync {
+    async fn generate(&self, request: GenerationRequest) -> Result<GenerationResponse, Box<dyn std::error::Error + Send + Sync>>;
+}
+
+#[async_trait]
+impl LLMEngine for LLMOrchestra {
+    async fn generate(&self, request: GenerationRequest) -> Result<GenerationResponse, Box<dyn std::error::Error + Send + Sync>> {
+        self.generate(request).await
+    }
+}
+
+#[derive(Clone)]
+pub struct LLMBridge {
+    engine: Arc<dyn LLMEngine>
+}
+
+impl LLMBridge {
+    pub fn new() -> Self {
+        Self { engine: Arc::new(LLMOrchestra::new()) }
+    }
+
+    pub fn with_engine(engine: Arc<dyn LLMEngine>) -> Self {
+        Self { engine }
+    }
+
+    pub async fn reason(&self, state: &finalverse_protocol::AgentState) -> String {
+        let request = GenerationRequest {
+            prompt: format!("What should agent {} do next?", state.id),
+            context: None,
+            player_id: None,
+            temperature: Some(0.5),
+            max_tokens: Some(32),
+        };
+        match self.engine.generate(request).await {
+            Ok(res) => res.text,
+            Err(_) => "".to_string(),
+        }
+    }
+}

--- a/crates/mapleai-agent/src/planner.rs
+++ b/crates/mapleai-agent/src/planner.rs
@@ -1,0 +1,16 @@
+use finalverse_protocol::{BehaviorAction, ReasoningContext};
+
+#[derive(Clone, Default)]
+pub struct Planner;
+
+impl Planner {
+    pub fn plan(&self, ctx: &ReasoningContext) -> BehaviorAction {
+        if ctx.tension > 0.7 {
+            BehaviorAction::Flee("danger".into())
+        } else if ctx.harmony_level < 0.3 {
+            BehaviorAction::Wander
+        } else {
+            BehaviorAction::Rest
+        }
+    }
+}

--- a/services/ai-orchestra/src/lib.rs
+++ b/services/ai-orchestra/src/lib.rs
@@ -1,0 +1,3 @@
+mod llm_integration;
+
+pub use llm_integration::{LLMOrchestra, GenerationRequest, GenerationResponse};


### PR DESCRIPTION
## Summary
- add `mapleai-agent` crate for simple agent behavior loops
- expose LLMOrchestra as a library
- register new crate in workspace

## Testing
- `cargo test -p mapleai-agent --locked --offline` *(fails: no matching package named `axum` found)*

------
https://chatgpt.com/codex/tasks/task_e_685245d111888332a68a366b1eb04fdf