### PR TITLE
Add simple agent API to behavior-ai

### DIFF
--- a/services/behavior-ai/Cargo.toml
+++ b/services/behavior-ai/Cargo.toml
@@ -12,3 +12,6 @@ axum.workspace = true
 tokio.workspace = true
 finalverse-logging.workspace = true
 tracing.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+mapleai-agent.workspace = true

--- a/services/behavior-ai/README.md
+++ b/services/behavior-ai/README.md
@@ -1,0 +1,35 @@
+# Behavior AI Service
+
+This microservice manages MapleAI agents and exposes a small HTTP API.
+
+## Endpoints
+
+### `POST /agent/spawn`
+Creates a new agent and stores it in memory.
+Request body:
+```json
+{ "id": "agent1", "region": "start" }
+```
+Response:
+```json
+{ "id": "agent1" }
+```
+
+### `POST /agent/{id}/act`
+Updates the agent context, performs one reasoning step and returns its next action.
+Request body example:
+```json
+{
+  "location": "town",
+  "nearby_entities": ["npc1"],
+  "harmony_level": 0.8,
+  "tension": 0.0,
+  "memory": []
+}
+```
+Response example:
+```json
+{ "action": { "kind": "rest" } }
+```
+
+Health information is available under `/health` and `/info`.

--- a/services/behavior-ai/src/main.rs
+++ b/services/behavior-ai/src/main.rs
@@ -1,9 +1,102 @@
-use axum::Router;
+use axum::{
+    extract::{Path, State},
+    routing::post,
+    Json, Router,
+};
 use finalverse_health::HealthMonitor;
 use service_registry::LocalServiceRegistry;
-use std::{net::SocketAddr, sync::Arc};
+use std::{collections::HashMap, net::SocketAddr, sync::Arc};
 use tracing::info;
 use finalverse_logging as logging;
+use serde::{Deserialize, Serialize};
+use tokio::sync::RwLock;
+use mapleai_agent::Agent;
+use finalverse_protocol::{BehaviorAction, ReasoningContext};
+
+type Agents = Arc<RwLock<HashMap<String, Agent>>>;
+
+#[derive(Clone)]
+struct AppState {
+    agents: Agents,
+}
+
+#[derive(Deserialize)]
+struct SpawnRequest {
+    id: String,
+    region: String,
+}
+
+#[derive(Serialize)]
+struct SpawnResponse {
+    id: String,
+}
+
+async fn spawn_agent(
+    State(state): State<AppState>,
+    Json(req): Json<SpawnRequest>,
+) -> Json<SpawnResponse> {
+    let mut agents = state.agents.write().await;
+    agents.insert(req.id.clone(), Agent::new(req.id.clone(), req.region));
+    Json(SpawnResponse { id: req.id })
+}
+
+#[derive(Deserialize)]
+struct ActRequest {
+    location: String,
+    nearby_entities: Vec<String>,
+    harmony_level: f32,
+    tension: f32,
+    memory: Vec<String>,
+}
+
+#[derive(Serialize)]
+struct ActResponse {
+    action: ActionDto,
+}
+
+#[derive(Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+enum ActionDto {
+    Wander,
+    Rest,
+    Flee { reason: String },
+    Migrate { target_region: String },
+    Interact { entity_id: String, action: String },
+}
+
+fn to_dto(action: BehaviorAction) -> ActionDto {
+    match action {
+        BehaviorAction::Wander => ActionDto::Wander,
+        BehaviorAction::Rest => ActionDto::Rest,
+        BehaviorAction::Flee(reason) => ActionDto::Flee { reason },
+        BehaviorAction::Migrate { target_region } => ActionDto::Migrate { target_region },
+        BehaviorAction::Interact { entity_id, action } => ActionDto::Interact { entity_id, action },
+    }
+}
+
+async fn act_agent(
+    Path(id): Path<String>,
+    State(state): State<AppState>,
+    Json(req): Json<ActRequest>,
+) -> Option<Json<ActResponse>> {
+    let mut agents = state.agents.write().await;
+    let agent = agents.get_mut(&id)?;
+
+    let ctx = ReasoningContext {
+        location: req.location,
+        nearby_entities: req.nearby_entities,
+        harmony_level: req.harmony_level,
+        tension: req.tension,
+        memory: req.memory,
+    };
+    agent.update_context(ctx);
+    agent.step().await;
+    if let Some(action) = agent.state().last_action.clone() {
+        Some(Json(ActResponse { action: to_dto(action) }))
+    } else {
+        None
+    }
+}
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -14,7 +107,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .register_service("behavior-ai".to_string(), "http://localhost:3011".to_string())
         .await;
 
-    let app = Router::new().merge(monitor.clone().axum_routes());
+    let state = AppState {
+        agents: Arc::new(RwLock::new(HashMap::new())),
+    };
+    let app = Router::new()
+        .route("/agent/spawn", post(spawn_agent))
+        .route("/agent/:id/act", post(act_agent))
+        .with_state(state)
+        .merge(monitor.clone().axum_routes());
 
     let addr = SocketAddr::from(([0, 0, 0, 0], 3011));
     info!("Behavior AI listening on {}", addr);


### PR DESCRIPTION
## Summary
- expose `/agent/spawn` and `/agent/{id}/act` on Behavior AI service
- keep in-memory agents and convert actions to JSON
- document endpoints in a new README

## Testing
- `cargo test -p behavior-ai` *(fails: failed to fetch crates from crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_68528fc825608332b374d7b1a28683ee