### PR TITLE
Document MapleAI protocol licenses

### DIFF
--- a/LICENSE_MAPLEAI.md
+++ b/LICENSE_MAPLEAI.md
@@ -1,0 +1,15 @@
+# MapleAI Integration Licensing
+
+MapleAI relies on several external protocols and frameworks to provide AI capabilities. The table below lists each reference and links to the source license or terms of use.
+
+| Protocol | Purpose in MapleAI | License / Terms |
+|---------|-------------------|----------------|
+| OpenAI API | Text generation via the `ai-orchestra` service. | [OpenAI API Terms of Use](https://openai.com/policies/terms-of-use) |
+| Anthropic Claude API | Optional provider for the LLM orchestra. | [Anthropic Terms of Use](https://www.anthropic.com/legal) |
+| Google Gemini API | Optional provider for the LLM orchestra. | [Google Generative AI Service Terms](https://ai.google.dev/terms) |
+| Mistral AI API | Optional provider for the LLM orchestra. | [Mistral Terms](https://mistral.ai/terms) |
+| Ollama API | Local LLM provider interface. | [Ollama License](https://github.com/ollama/ollama/blob/main/LICENSE) |
+| ONNX Runtime | Local model execution through the `ort` crate. | [MIT License](https://github.com/microsoft/onnxruntime/blob/main/LICENSE) |
+| gRPC / Protocol Buffers | Internal service communication. | [BSD-3-Clause](https://github.com/protocolbuffers/protobuf/blob/main/LICENSE) |
+
+When extending MapleAI, ensure that any new integrations comply with these upstream licenses and terms. Contributors must include appropriate attribution where required and respect the usage limitations of each provider.

--- a/README.md
+++ b/README.md
@@ -152,6 +152,12 @@ This MVP focuses on the core loop of songweaving, world simulation and AI intera
 - **0.1.1** - First official release with working setup scripts and Docker deployment.
 - **0.1.0** - Initial proof-of-concept MVP. See `CHANGELOG.md` for details.
 
+## MapleAI External Protocols
+
+MapleAI integrates with several external APIs to support different language model providers (OpenAI, Claude, Gemini, Mistral and Ollama). It also uses the ONNX Runtime for local models and relies on gRPC/Protocol Buffers for service communication. The specific licenses or terms for these protocols are listed in [LICENSE_MAPLEAI.md](LICENSE_MAPLEAI.md).
+
+Contributors extending MapleAI must review those upstream licenses and comply with any attribution or usage requirements.
+
 ## License
 
 © 2025 Finalverse Inc. All rights reserved.


### PR DESCRIPTION
## Summary
- document MapleAI's external APIs and protocol licenses in new LICENSE_MAPLEAI.md
- mention MapleAI protocol requirements in README

## Testing
- `cargo test --workspace --quiet` *(fails: network access blocked while fetching crates)*

------
https://chatgpt.com/codex/tasks/task_e_6852dde2d90c833293fa973c6e89f9a6